### PR TITLE
Add ability to pass options in the callback; move url; fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,14 +38,14 @@ import { useOpenInWindow }  from 'use-open-window';
 const url = 'https://www.google.com/';
 const options = {
    centered: true, /* default */
-   spec: {
+   specs: {
       width: 800, /* window width */
       height: 600, /* window height */
    }
 };
 const App = () => {
   const [handleWindowOpen, newWindowHandle] = useOpenInWindow(url, options);
-  
+
   return (
     <div className="App">
       <div onClick={handleWindowOpen}>Click me</div>

--- a/src/useOpenInWindow.test.tsx
+++ b/src/useOpenInWindow.test.tsx
@@ -8,7 +8,7 @@ describe("useOpenInWindow()", () => {
   it("should wait for callback invoke", () => {
     const spy = jest.spyOn(global as any, "open");
     const HookTestComponent: React.FunctionComponent<any> = () => {
-      const [handleWindowOpen] = useOpenInWindow("blabla");
+      const [handleWindowOpen] = useOpenInWindow({ url: "blabla" });
       return (
         <div>
           <div data-testid="onClickHandler" onClick={handleWindowOpen}></div>
@@ -26,7 +26,7 @@ describe("useOpenInWindow()", () => {
     (global as any).open = windowOpenMock;
     const url = "/blabla";
     const HookTestComponent: React.FunctionComponent<any> = () => {
-      const [handleWindowOpen] = useOpenInWindow(url);
+      const [handleWindowOpen] = useOpenInWindow({ url });
       return (
         <div>
           <div data-testid="onClickHandler" onClick={handleWindowOpen}></div>
@@ -51,7 +51,7 @@ describe("useOpenInWindow()", () => {
     (global as any).open = jest.fn(() => newWindowMock);
     const url = "/blabla";
     const HookTestComponent: React.FunctionComponent<any> = () => {
-      const [handleWindowOpen] = useOpenInWindow(url);
+      const [handleWindowOpen] = useOpenInWindow({ url });
       return (
         <div>
           <div data-testid="onClickHandler" onClick={handleWindowOpen}></div>
@@ -72,7 +72,7 @@ describe("useOpenInWindow()", () => {
     (global as any).open = jest.fn(() => newWindowMock);
     const url = "/blabla";
     const HookTestComponent: React.FunctionComponent<any> = () => {
-      const [handleWindowOpen] = useOpenInWindow(url, { centered: false });
+      const [handleWindowOpen] = useOpenInWindow({ url, centered: false });
       return (
         <div>
           <div data-testid="onClickHandler" onClick={handleWindowOpen}></div>

--- a/src/useOpenInWindow.ts
+++ b/src/useOpenInWindow.ts
@@ -6,6 +6,7 @@ import { windowOptionsMapper } from './windowOptionsMapper';
 export type SpecsOption = 'yes' | 'no' | 1 | 0;
 
 export interface UseOpenInWindowOptions {
+  url: string,
   /* Specifies the target attribute or the name of the window. The following values are supported:
         _blank - URL is loaded into a new window, or tab. This is default
         _parent - URL is loaded into the parent frame
@@ -51,6 +52,7 @@ export interface UseOpenInWindowOptions {
 }
 
 export const defaultOptions: Required<UseOpenInWindowOptions> = {
+  url: '',
   name: '_blank',
   centered: true,
   focus: true,
@@ -61,18 +63,19 @@ export const defaultOptions: Required<UseOpenInWindowOptions> = {
   }
 };
 
-export const useOpenInWindow = (url: string, options: UseOpenInWindowOptions = {}) => {
+export const useOpenInWindow = (options: UseOpenInWindowOptions = { url: '' }) => {
   const [newWindowHandler, setNewWindowHandler] = useState<Window | null>();
   const openInWindow = useCallback(
-    (event: React.MouseEvent) => {
+    (event: React.MouseEvent, callbackOptions: UseOpenInWindowOptions = { url: '' }) => {
       if (event) {
         event.preventDefault();
       }
 
       const { specs } = options;
       const { specs: defaultSpecs } = defaultOptions;
-      const mixedOptions = { ...defaultOptions, ...options };
-      const mixedSpecs = { ...defaultSpecs, ...specs };
+      const { specs: callbackSpecs } = callbackOptions;
+      const mixedOptions = { ...defaultOptions, ...options, ...callbackOptions };
+      const mixedSpecs = { ...defaultSpecs, ...specs, ...callbackSpecs };
       const { focus, name, centered } = mixedOptions;
       let windowOptions = '';
 
@@ -84,14 +87,14 @@ export const useOpenInWindow = (url: string, options: UseOpenInWindowOptions = {
         windowOptions = windowOptionsMapper(mixedSpecs);
       }
 
-      const newWindow = window.open(url, name, windowOptions);
+      const newWindow = window.open(mixedOptions.url, name, windowOptions);
 
       // Puts focus on the newWindow
       if (focus && newWindow) newWindow.focus();
 
       setNewWindowHandler(newWindow);
     },
-    [url, options, setNewWindowHandler]
+    [options, setNewWindowHandler]
   );
 
   return [openInWindow, newWindowHandler] as [() => void, Window | null | undefined];


### PR DESCRIPTION
Thanks for a useful library!

1. Added a way to pass options to the window in the callback too. This is a common scenario when for example - opening a window in response to form submit and you want to pass the data to the window via url (f.e. formik onSubmit).
2. This is a breaking change since this changes the initial hook params. Moved the url into the options object (otherwise we'd have to push multiple args into the callback args too). Feel free to improve the typescript types, as I've just defaulted url to `''` at this point not to break the linter.
3. Fixed a small typo in the README example.

Good luck!