### PR TITLE
Fix/package-exports-order 

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "source": "src/index.js",
   "exports": {
     "require": "./dist/index.cjs",
-    "default": "./dist/index.modern.js",
-    "types": "./dist/index.d.ts"
+    "types": "./dist/index.d.ts",
+    "default": "./dist/index.modern.js"
   },
   "main": "./dist/index.cjs",
   "module": "./dist/index.module.js",


### PR DESCRIPTION
In our next.js shop I'm getting the following error.
```
Module not found: Default condition should be last one
```

This is caused by the package.json exports order not having default as the last export. This error was introduced by #315 .